### PR TITLE
Adding pypi deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,3 +51,10 @@ after_success:
   - conda install conda-build anaconda-client
   - conda config --set anaconda_upload yes
   - conda build --token $CONDA_UPLOAD_TOKEN --python $PYTHON_VERSION .
+deploy:
+  provider: pypi
+  user: tisaconundrum
+  password: $PYPI_PASSWORD
+  distributions: sdist bdist_wheel
+  on:
+    branch: master


### PR DESCRIPTION
We need to deploy to PyPi so users can get the latest libpysat library, or they're going to have a bad time